### PR TITLE
fix(tags): Fix tags naming

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mdbook-sitemap-generator"
-version = "0.2.0"
+version = "0.3.0"
 edition = "2021"
 license = "MIT"
 description = "Utility to generate a sitemap.xml file for an mdbook project"

--- a/src/builder.rs
+++ b/src/builder.rs
@@ -5,10 +5,8 @@ use quick_xml::{DeError, se::to_string};
 #[derive(Debug, Serialize, PartialEq, Eq)]
 #[serde(rename = "urlset")]
 pub(crate) struct UrlSet {
-    #[serde(rename = "@xlmns")]
-    pub xlmns: String,
-
-    pub urls: Vec<Url>
+    pub xmlns: String,
+    pub url: Vec<Url>
 }
 
 #[derive(Debug, PartialEq, Eq)]
@@ -20,8 +18,8 @@ pub(crate) struct Url {
 impl UrlSet {
     pub fn new(urls: Vec<String>) -> Self {
         UrlSet {
-            xlmns: "http://www.sitemaps.org/schemas/sitemap/0.9".to_string(),
-            urls: urls
+            xmlns: "http://www.sitemaps.org/schemas/sitemap/0.9".to_string(),
+            url: urls
                 .into_iter()
                 .map(|url| Url {
                     loc: url.replace(".md",".html"),
@@ -32,7 +30,7 @@ impl UrlSet {
     }
 
     pub fn to_xml(&self) -> Result<String,DeError> {
-        return to_string(&self);
+        to_string(&self);
     }
 }
 

--- a/src/builder.rs
+++ b/src/builder.rs
@@ -30,7 +30,7 @@ impl UrlSet {
     }
 
     pub fn to_xml(&self) -> Result<String,DeError> {
-        to_string(&self);
+        to_string(&self)
     }
 }
 


### PR DESCRIPTION
This fixes the sitemap generation by renaming `xlmns` to `xmlns` and `urls` to `url`. Also, there was a warning for a not required return, which was fixed.

Fixes #2 