### PR TITLE
Fix cargo install error type, bump version #7

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -103,7 +103,7 @@ checksum = "b4668fb0ea861c1df094127ac5f1da3409a82116a4ba74fca2e58ef927159bb3"
 
 [[package]]
 name = "mdbook-sitemap-generator"
-version = "0.1.0"
+version = "0.3.0"
 dependencies = [
  "clap",
  "quick-xml",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mdbook-sitemap-generator"
-version = "0.2.0"
+version = "0.3.0"
 edition = "2021"
 license = "MIT"
 description = "Utility to generate a sitemap.xml file for an mdbook project"

--- a/src/builder.rs
+++ b/src/builder.rs
@@ -1,6 +1,7 @@
+use clap::Error;
+use quick_xml::se::to_string;
 use serde::ser::SerializeMap;
 use serde::{Serialize, Serializer};
-use quick_xml::{DeError, se::to_string};
 
 #[derive(Debug, Serialize, PartialEq, Eq)]
 #[serde(rename = "urlset")]
@@ -8,7 +9,7 @@ pub(crate) struct UrlSet {
     #[serde(rename = "@xlmns")]
     pub xlmns: String,
 
-    pub urls: Vec<Url>
+    pub urls: Vec<Url>,
 }
 
 #[derive(Debug, PartialEq, Eq)]
@@ -24,15 +25,15 @@ impl UrlSet {
             urls: urls
                 .into_iter()
                 .map(|url| Url {
-                    loc: url.replace(".md",".html"),
+                    loc: url.replace(".md", ".html"),
                     priority: Some("1.0".to_string()),
                 })
                 .collect(),
         }
     }
 
-    pub fn to_xml(&self) -> Result<String,DeError> {
-        return to_string(&self);
+    pub fn to_xml(&self) -> Result<String, std::io::Error> {
+        to_string(&self).map_err(|e| std::io::Error::new(std::io::ErrorKind::Other, e))
     }
 }
 


### PR DESCRIPTION
See #7 

The types didn't work. This should at least compile, although it does get rid of error details.